### PR TITLE
Fix-ebs-role-creation

### DIFF
--- a/ai-ml/emr-spark-rapids/addons.tf
+++ b/ai-ml/emr-spark-rapids/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/ai-ml/jupyterhub/addons.tf
+++ b/ai-ml/jupyterhub/addons.tf
@@ -21,6 +21,7 @@ locals {
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s", local.name, "ebs-csi-driver-")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/ai-ml/trainium-inferentia/addons.tf
+++ b/ai-ml/trainium-inferentia/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/analytics/terraform/datahub-on-eks/addons.tf
+++ b/analytics/terraform/datahub-on-eks/addons.tf
@@ -91,6 +91,7 @@ module "eks_blueprints_addons" {
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.14"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/analytics/terraform/emr-eks-ack/addons.tf
+++ b/analytics/terraform/emr-eks-ack/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/analytics/terraform/emr-eks-karpenter/addons.tf
+++ b/analytics/terraform/emr-eks-karpenter/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/distributed-databases/cloudnative-postgres/resources.tf
+++ b/distributed-databases/cloudnative-postgres/resources.tf
@@ -10,6 +10,7 @@ resource "random_string" "random" {
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.14"
+  create_role           = true
   role_name             = format("%s-%s", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/schedulers/terraform/self-managed-airflow/addons.tf
+++ b/schedulers/terraform/self-managed-airflow/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s-", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/streaming/flink/addons.tf
+++ b/streaming/flink/addons.tf
@@ -4,6 +4,7 @@
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.20"
+  create_role           = true
   role_name_prefix      = format("%s-%s", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {

--- a/streaming/kafka/addons.tf
+++ b/streaming/kafka/addons.tf
@@ -5,7 +5,8 @@
 module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.20"
-
+  
+  create_role      = true
   role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
 
   attach_ebs_csi_policy = true

--- a/streaming/nifi/addons.tf
+++ b/streaming/nifi/addons.tf
@@ -6,6 +6,7 @@ module "ebs_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.20"
 
+  create_role      = true
   role_name_prefix = "${module.eks.cluster_name}-ebs-csi-driver-"
 
   attach_ebs_csi_policy = true

--- a/workshop/emr-eks/modules/addons/main.tf
+++ b/workshop/emr-eks/modules/addons/main.tf
@@ -202,6 +202,7 @@ resource "aws_prometheus_workspace" "amp" {
 module "ebs_csi_driver_irsa" {
   source                = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version               = "~> 5.14"
+  create_role           = true
   role_name             = format("%s-%s", local.name, "ebs-csi-driver")
   attach_ebs_csi_policy = true
   oidc_providers = {


### PR DESCRIPTION
Add role creation to the EBS CSI Driver for all use cases.

A new install fails because the ebs_csi_driver_irsa module does not attache the ebs_csi_policy to the role unless this is set to true.